### PR TITLE
ci: make ggscout secrets optional for caller flexibility

### DIFF
--- a/.github/workflows/ggscout.yml
+++ b/.github/workflows/ggscout.yml
@@ -5,9 +5,9 @@ on:
   workflow_call:
     secrets:
       GGSCOUT_GITHUB_TOKEN:
-        required: true
+        required: false
       GGSCOUT_GHAPP_SECRETKEY:
-        required: true
+        required: false
 
 jobs:
   inventory:


### PR DESCRIPTION
## Summary
- Make `GGSCOUT_GITHUB_TOKEN` and `GGSCOUT_GHAPP_SECRETKEY` optional in the reusable workflow
- Allows callers to use `secrets: inherit` with org-level secrets without failing validation
