### PR TITLE
fix: correct ggscout secret mapping

### DIFF
--- a/.github/workflows/ggscout.yml
+++ b/.github/workflows/ggscout.yml
@@ -4,9 +4,9 @@ name: ggscout NHI Inventory
 on:
   workflow_call:
     secrets:
-      GGSCOUT_GITHUB_TOKEN:
-        required: false
       GGSCOUT_GHAPP_SECRETKEY:
+        required: false
+      GGSCOUT_GITGUARDIAN_API_KEY:
         required: false
 
 jobs:
@@ -37,6 +37,6 @@ jobs:
       env:
         GGSCOUT_GITHUB_ACTION_SECRETS: ${{ toJSON(secrets) }}
         GGSCOUT_GITHUB_ACTION_CONTEXT: ${{ toJSON(github) }}
-        GGSCOUT_GITHUB_API_TOKEN: ${{ secrets.GGSCOUT_GITHUB_TOKEN }}
-        GITGUARDIAN_API_KEY: ${{ secrets.GGSCOUT_GHAPP_SECRETKEY }}
+        GGSCOUT_GITHUB_API_TOKEN: ${{ secrets.GGSCOUT_GHAPP_SECRETKEY }}
+        GITGUARDIAN_API_KEY: ${{ secrets.GGSCOUT_GITGUARDIAN_API_KEY }}
       run: ggscout fetch-and-send /tmp/config.toml

--- a/workflow-templates/ggscout.yml
+++ b/workflow-templates/ggscout.yml
@@ -34,6 +34,6 @@ EOF
       env:
         GGSCOUT_GITHUB_ACTION_SECRETS: ${{ toJSON(secrets) }}
         GGSCOUT_GITHUB_ACTION_CONTEXT: ${{ toJSON(github) }}
-        GGSCOUT_GITHUB_API_TOKEN: ${{ secrets.GGSCOUT_GITHUB_TOKEN }}
-        GITGUARDIAN_API_KEY: ${{ secrets.GGSCOUT_GHAPP_SECRETKEY }}
+        GGSCOUT_GITHUB_API_TOKEN: ${{ secrets.GGSCOUT_GHAPP_SECRETKEY }}
+        GITGUARDIAN_API_KEY: ${{ secrets.GGSCOUT_GITGUARDIAN_API_KEY }}
       run: ggscout fetch-and-send /tmp/config.toml


### PR DESCRIPTION
GGSCOUT_GHAPP_SECRETKEY (GitHub App private key) was incorrectly mapped to GITGUARDIAN_API_KEY, causing TOML parse errors when the multi-line PEM key was substituted into the config.

Fix the mapping:
- GGSCOUT_GHAPP_SECRETKEY → GGSCOUT_GITHUB_API_TOKEN (GitHub API auth)
- GGSCOUT_GITGUARDIAN_API_KEY → GITGUARDIAN_API_KEY (GitGuardian API token)

It worked: https://github.com/GitGuardian/ggbridge/actions/runs/24512826607/job/71648367898